### PR TITLE
Add Lock Codes to support change in SmartApp

### DIFF
--- a/devicetypes/mitchpond/centralite-keypad.src/centralite-keypad.groovy
+++ b/devicetypes/mitchpond/centralite-keypad.src/centralite-keypad.groovy
@@ -15,11 +15,12 @@
  */
 metadata {
 	definition (name: "Centralite Keypad", namespace: "mitchpond", author: "Mitch Pond") {
-		capability "Battery"
+	capability "Battery"
         capability "Configuration"
-		capability "Sensor"
+	capability "Sensor"
         capability "Temperature Measurement"
         capability "Refresh"
+        capability "Lock Codes"
         
         attribute "armMode", "String"
         


### PR DESCRIPTION
Add Lock Codes capability to support change in SmartApp to fix Android device finding error.
