### PR TITLE
Adding Iris Keypad Fingerprint

### DIFF
--- a/devicetypes/mitchpond/centralite-keypad.src/centralite-keypad.groovy
+++ b/devicetypes/mitchpond/centralite-keypad.src/centralite-keypad.groovy
@@ -34,6 +34,7 @@ metadata {
         command "acknowledgeArmRequest"
         
         fingerprint endpointId: "01", profileId: "0104", deviceId: "0401", inClusters: "0000,0001,0003,0020,0402,0500,0B05", outClusters: "0019,0501", manufacturer: "CentraLite", model: "3400"
+        fingerprint endpointId: "01", profileId: "0104", deviceId: "0401", inClusters: "0000,0001,0003,0020,0402,0500,0501,0B05,FC04", outClusters: "0019,0501", manufacturer: "CentraLite", model: "3405-L"
 	}
 
 	tiles {


### PR DESCRIPTION
This should allow users to add the IRIS keypad without having to assign the DTH manually in IDE.
