### PR TITLE
Tripper voltage/battery percentage edits

### DIFF
--- a/devicetypes/mitchpond/quirky-wink-tripper.src/quirky-wink-tripper.groovy
+++ b/devicetypes/mitchpond/quirky-wink-tripper.src/quirky-wink-tripper.groovy
@@ -197,14 +197,16 @@ private parseIasMessage(String description) {
 //Converts the battery level response into a percentage to display in ST
 //and creates appropriate message for given level
 
+//ADM - 8-31 Added mapping values for 30 and 29 to map below -since they were valid values - 3 or 2.9  volts were returning null
+
 private getBatteryResult(volts) {
-	def batteryMap = [28:100, 27:100, 26:75, 25:50, 24:25, 23:20,
+	def batteryMap = [30:100, 29:100, 28:100, 27:95, 26:75, 25:50, 24:25, 23:20,
                           22:10, 21:0]
 	def minVolts = 21
 	def maxVolts = 30
 	def linkText = getLinkText(device)
 	def result = [name: 'battery']
-	log.debug("${linkText} reports batery voltage at ${rawValue/10}") //added logging for voltage level to help determine actual min voltage from users
+	log.debug("${linkText} reports battery voltage at ${volts/10}") //added logging for voltage level to help determine actual min voltage from users
     
     if (volts < minVolts) volts = minVolts
     	else if (volts > maxVolts) volts = maxVolts

--- a/devicetypes/mitchpond/quirky-wink-tripper.src/quirky-wink-tripper.groovy
+++ b/devicetypes/mitchpond/quirky-wink-tripper.src/quirky-wink-tripper.groovy
@@ -200,7 +200,7 @@ private parseIasMessage(String description) {
 //ADM - 8-31 Added mapping values for 30 and 29 to map below -since they were valid values - 3 or 2.9  volts were returning null
 
 private getBatteryResult(volts) {
-	def batteryMap = [30:100, 29:100, 28:100, 27:95, 26:75, 25:50, 24:25, 23:20,
+	def batteryMap = [30:100, 29:95, 28:90, 27:80, 26:75, 25:50, 24:25, 23:20,
                           22:10, 21:0]
 	def minVolts = 21
 	def maxVolts = 30


### PR DESCRIPTION
@mitchpond 

First time trying this w/ Github  - hope I got protocol/process right. I think this is from your most recent June 6th version.  

I made a couple of tweaks to your great Tripper Device Type. Not an expert but I think they work. 

Edited getBatteryResult 
- corrected variable for log.debug (rawValue => volts)
- added mapping values for 3.0 and 2.9 volts (new batteries were showing null values).  Also changed mappings for 28 and 27 just because I want to see more intermediate values as it starts to decrease.  I'm frankly tempted to just show the voltage but that would be confusing to most. 

Agree with your assessment on voltage. Under 2.1 or so seems to start giving problems. 
