### PR TITLE
Centralite Keypad reporting 0% battery after Groovy update

### DIFF
--- a/devicetypes/mitchpond/centralite-keypad.src/centralite-keypad.groovy
+++ b/devicetypes/mitchpond/centralite-keypad.src/centralite-keypad.groovy
@@ -217,15 +217,18 @@ private getBatteryResult(rawValue) {
 	def result = [name: 'battery']
 
 	def volts = rawValue / 10
-	def descriptionText
+
 	if (volts > 3.5) {
 		result.descriptionText = "${linkText} battery has too much power (${volts} volts)."
 	}
 	else {
 		def minVolts = 2.1
 		def maxVolts = 3.0
-		def pct = (volts - minVolts) / (maxVolts - minVolts)
-		result.value = Math.min(100, (int) pct * 100)
+		def pct = Math.round(((volts - minVolts) / (maxVolts - minVolts)) * 100)
+		if (pct <= 0) {
+			pct = 1
+		}
+		result.value = Math.min(100, pct)
 		result.descriptionText = "${linkText} battery was ${result.value}%"
 	}
 


### PR DESCRIPTION
The recent Groovy update changed how the following line of code works:

    result.value = Math.min(100, (int) pct * 100)

Previously the multiplication would happen before the typecast so it would yield the desired result. With the new version of Groovy that's now used to run DTHs the typecast happens before the multiplication, so any value of `pct` between 0 and 1 would be truncated to 0 resulting in a battery percentage of 0%. This change fixes that issue, plus rounds to the nearest percentage instead of truncating and uses a minimum percentage of 1 instead of 0. The reasoning behind that is if the battery message is received at all then it has at least a little bit of juice left.